### PR TITLE
Fix to hide default image if uploaded images are less than 6 and have the layout dynamic

### DIFF
--- a/views/item/detail.jade
+++ b/views/item/detail.jade
@@ -2,35 +2,41 @@ extends ../layout
 
 block content
   h2.display-data Item Detail
-  img(src='/images/' + item.imageFileNames[0] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[1] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[2] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  br
-  img(src='/images/' + item.imageFileNames[3] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[4] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[5] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  table.table.table-bordered
-    tr
-      th Property
-      th Value
-        tr
-          td Title
-          td= display(item.title)
-        tr
-          td Description
-          td= display(item.description)
-        tr
-          td Category
-          td= display(item.category)
-        tr
-          td Condition
-            a(href="/conditions/", target="_blank", title="Conditions")
-              i.glyphicon.glyphicon-info-sign
-          td= display(item.condition)
+  -if (item.imageFileNames[0] != null)
+     img(src='/images/' + item.imageFileNames[0] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+     = ' '
+  -if (item.imageFileNames[1] != null)
+     img(src='/images/' + item.imageFileNames[1] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+     = ' '
+  -if (item.imageFileNames[2] != null)
+     img(src='/images/' + item.imageFileNames[2] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+     br
+  -if (item.imageFileNames[3] != null)
+     img(src='/images/' + item.imageFileNames[3] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+     = ' '
+  -if (item.imageFileNames[4] != null)
+     img(src='/images/' + item.imageFileNames[4] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+     = ' '
+  -if (item.imageFileNames[5] != null)
+     img(src='/images/' + item.imageFileNames[5] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+    table.table.table-bordered
+      tr
+        th Property
+        th Value
+          tr
+            td Title
+            td= display(item.title)
+          tr
+            td Description
+            td= display(item.description)
+          tr
+            td Category
+            td= display(item.category)
+          tr
+            td Condition
+              a(href="/conditions/", target="_blank", title="Conditions")
+                i.glyphicon.glyphicon-info-sign
+            td= display(item.condition)
 
   .form-actions
     a.btn.btn-warning(href="/items") Back

--- a/views/item/image_upload.jade
+++ b/views/item/image_upload.jade
@@ -2,17 +2,23 @@ extends ../layout
 include ../mixins/form-helpers
 
 block content
-  img(src='/images/' + item.imageFileNames[0] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[1] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[2] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  br
-  img(src='/images/' + item.imageFileNames[3] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[4] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
-  = ' '
-  img(src='/images/' + item.imageFileNames[5] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+  -if (item.imageFileNames[0] != null)
+   img(src='/images/' + item.imageFileNames[0] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+   = ' '
+  -if (item.imageFileNames[1] != null)
+   img(src='/images/' + item.imageFileNames[1] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+   = ' '
+  -if (item.imageFileNames[2] != null)
+   img(src='/images/' + item.imageFileNames[2] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+   br
+  -if (item.imageFileNames[3] != null)
+   img(src='/images/' + item.imageFileNames[3] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+   = ' '
+  -if (item.imageFileNames[4] != null)
+   img(src='/images/' + item.imageFileNames[4] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
+   = ' '
+  -if (item.imageFileNames[5] != null)
+   img(src='/images/' + item.imageFileNames[5] width="250" height="auto" onerror="this.onerror=null;this.src='/images/slug.png';this.width=250;this.height=auto;")
   form#item-form(action="/items/" + item._id + "/edit", method="POST", role="form")
     fieldset
       legend Image Upload


### PR DESCRIPTION
User can upload upto 6 images, if the number of images are less than 6 (for example 3) then it will scale the area accordingly and not display default ( holder ) image